### PR TITLE
Alter sidemenu z-index

### DIFF
--- a/src/bulma/main.scss
+++ b/src/bulma/main.scss
@@ -106,7 +106,7 @@ $sizes: 50 100 150 200 250 300 350 400 450 500 550 600 650 700 750 800 850 900 9
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 1;
+  z-index: 2;
   width: 220px;
   height: 100%;
   padding-top: 10px;


### PR DESCRIPTION
Augments z-index to compensate the scoreboard's header z-index, which is also one, causing the issue described in #110.